### PR TITLE
Fix cron command to work with latest version of FlexGet

### DIFF
--- a/cron.d/flexget
+++ b/cron.d/flexget
@@ -1,2 +1,2 @@
 # m h dom mon dow user  command
-0 *   * * *   abc    /usr/local/bin/flexget -c /config/config.yml execute --loglevel debug --now 2>&1 | logger -t FlexGet
+0 *   * * *   abc    /usr/local/bin/flexget -c /config/config.yml --loglevel debug --now execute 2>&1 | logger -t FlexGet

--- a/cron.d/flexget
+++ b/cron.d/flexget
@@ -1,2 +1,2 @@
 # m h dom mon dow user  command
-0 *   * * *   abc    /usr/local/bin/flexget -c /config/config.yml --loglevel debug --now execute 2>&1 | logger -t FlexGet
+0 *   * * *   abc    /usr/local/bin/flexget -c /config/config.yml --loglevel debug execute 2>&1 | logger -t FlexGet


### PR DESCRIPTION
Thanks for putting this container together!

I was running into the following error whenever the default cron command was run:

```
Nov 24 21:00:01 0a6cff01e6d2 /USR/SBIN/CRON[734]: (abc) CMD (   /usr/local/bin/flexget -c /config/config.yml execute --loglevel debug --now 2>&1 | logger -t FlexGet)
Nov 24 21:00:03 0a6cff01e6d2 FlexGet: usage: flexget [-h] [-V] [--test] [-c CONFIG] [--logfile LOGFILE]
Nov 24 21:00:03 0a6cff01e6d2 FlexGet:                [--loglevel LEVEL] [--bugreport] [--profile [OUTFILE]] [--cron]
Nov 24 21:00:03 0a6cff01e6d2 FlexGet:                [--debug-db-sessions] [--debug-warnings]
Nov 24 21:00:03 0a6cff01e6d2 FlexGet:                <command> ...
Nov 24 21:00:03 0a6cff01e6d2 FlexGet: flexget: error: unrecognized arguments: --loglevel debug
```

After reordering the arguments so `execute` came at the end, I stopped seeing errors in the docker logs, but Transmission wasn't working.  After `exec`-ing into the box, I tried running the command manually and ran into this error:

```
usage: flexget [-h] [-V] [--test] [-c CONFIG] [--logfile LOGFILE]
               [--loglevel LEVEL] [--bugreport] [--profile [OUTFILE]] [--cron]
               [--debug-db-sessions] [--debug-warnings]
               <command> ...
flexget: error: unrecognized arguments: --now
```

I removed the `--now` flag, and the cron command worked great!  My guess is that FlexGet has changed since this image was created a few months ago and just needed updating.

The cron command in this PR is the one that works for me; let me know if you have any issues or questions!