### PR TITLE
Add request for updated chardet via pip install

### DIFF
--- a/etc/cont-init.d/20-update-flexget
+++ b/etc/cont-init.d/20-update-flexget
@@ -5,5 +5,5 @@ pip install -U pip
 # https://github.com/pypa/setuptools/issues/951
 pip install -U setuptools>=36
 pip install -U urllib3[socks]
-pip isntall -U chardet
+pip install -U chardet
 pip install -U flexget

--- a/etc/cont-init.d/20-update-flexget
+++ b/etc/cont-init.d/20-update-flexget
@@ -5,4 +5,5 @@ pip install -U pip
 # https://github.com/pypa/setuptools/issues/951
 pip install -U setuptools>=36
 pip install -U urllib3[socks]
+pip isntall -U chardet
 pip install -U flexget


### PR DESCRIPTION
Prevent warning thrown with every execution of flexget cli. Fix for issue #21.