### PR TITLE
Add irc_bot to 20-update-flexget.

### DIFF
--- a/etc/cont-init.d/20-update-flexget
+++ b/etc/cont-init.d/20-update-flexget
@@ -7,3 +7,4 @@ pip install -U setuptools>=36
 pip install -U urllib3[socks]
 pip install -U chardet
 pip install -U flexget
+pip install -U irc_bot


### PR DESCRIPTION
irc_bot is a dependency for flexget if you want to use irc functionality.

More info here...
https://flexget.com/Plugins/Daemon/irc