### PR TITLE
revert edge packages now that edge is python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,15 @@ FROM lsiobase/alpine:3.10
 
 # Add edge/testing repositories.
 RUN printf "\
-@edge http://nl.alpinelinux.org/alpine/edge/main\n\
 @testing http://nl.alpinelinux.org/alpine/edge/testing\n\
-@community http://nl.alpinelinux.org/alpine/edge/community\n\
 " >> /etc/apk/repositories
 
 RUN apk add \
-    python3@edge \
-    python3-dev@edge \
-    py3-lxml@edge \
-    boost-python3@edge  \
-    bash@edge \
-    g++@edge \
-    gcc@edge
+    python3 \
+    python3-dev \
+    py3-lxml \
+    boost-python3  \
+    bash
 
 RUN \
  echo "**** install build packages ****" && \
@@ -27,6 +23,8 @@ RUN \
     autoconf \
     automake \
     freetype-dev \
+    g++ \
+    gcc \
     jpeg-dev \
     lcms2-dev \
     libffi-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,16 @@
 # - installing python 3.7.3 because that is what py3-libtorrent-rasterbar requires (doesn't work with 3.6.8)
 FROM lsiobase/alpine:3.10
 
-# Add edge/testing repositories.
-RUN printf "\
-@testing http://nl.alpinelinux.org/alpine/edge/testing\n\
-" >> /etc/apk/repositories
-
 RUN apk add \
     python3 \
     python3-dev \
     py3-lxml \
     boost-python3  \
-    bash
+    bash && \
+    echo "**** install alpine sdk so that we can build libtorrent python bindings (for various plugin) ****" && \
+    apk add alpine-sdk && \
+    abuild-keygen -ian && \
+    usermod -aG abuild root
 
 RUN \
  echo "**** install build packages ****" && \
@@ -77,10 +76,18 @@ RUN \
     setuptools \
     urllib3 \
     virtualenv && \
+ echo "**** build libtorrent-rasterbar, this takes a bit ****" && \
+ mkdir -p /build/py3-libtorrent-rasterbar && \
+ cd /build/py3-libtorrent-rasterbar && \
+ wget https://git.alpinelinux.org/aports/plain/testing/libtorrent-rasterbar/APKBUILD && \
+ abuild -F checksum && abuild -Fr && \
+ apk add --repository /root/packages/build py3-libtorrent-rasterbar && \
  echo "**** clean up ****" && \
  rm -rf \
     /root/.cache \
-    /tmp/*
+    /tmp/* \
+    /build \
+    /root/packages
 
 ##############################################################################
 # Here starts the usual changes compared to baseimage.

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,17 +5,16 @@
 # - installing python 3.7.3 because that is what py3-libtorrent-rasterbar requires (doesn't work with 3.6.8)
 FROM lsiobase/alpine:arm64v8-3.10
 
-# Add edge/testing repositories.
-RUN printf "\
-@testing http://nl.alpinelinux.org/alpine/edge/testing\n\
-" >> /etc/apk/repositories
-
 RUN apk add \
     python3 \
     python3-dev \
     py3-lxml \
     boost-python3  \
-    bash
+    bash && \
+    echo "**** install alpine sdk so that we can build libtorrent python bindings (for various plugin) ****" && \
+    apk add alpine-sdk && \
+    abuild-keygen -ian && \
+    usermod -aG abuild root
 
 RUN \
  echo "**** install build packages ****" && \
@@ -77,10 +76,18 @@ RUN \
     setuptools \
     urllib3 \
     virtualenv && \
+ echo "**** build libtorrent-rasterbar, this takes a bit ****" && \
+ mkdir -p /build/py3-libtorrent-rasterbar && \
+ cd /build/py3-libtorrent-rasterbar && \
+ wget https://git.alpinelinux.org/aports/plain/testing/libtorrent-rasterbar/APKBUILD && \
+ abuild -F checksum && abuild -Fr && \
+ apk add --repository /root/packages/build py3-libtorrent-rasterbar && \
  echo "**** clean up ****" && \
  rm -rf \
     /root/.cache \
-    /tmp/*
+    /tmp/* \
+    /build \
+    /root/packages
 
 ##############################################################################
 # Here starts the usual changes compared to baseimage.

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -7,19 +7,15 @@ FROM lsiobase/alpine:arm64v8-3.10
 
 # Add edge/testing repositories.
 RUN printf "\
-@edge http://nl.alpinelinux.org/alpine/edge/main\n\
 @testing http://nl.alpinelinux.org/alpine/edge/testing\n\
-@community http://nl.alpinelinux.org/alpine/edge/community\n\
 " >> /etc/apk/repositories
 
 RUN apk add \
-    python3@edge \
-    python3-dev@edge \
-    py3-lxml@edge \
-    boost-python3@edge  \
-    bash@edge \
-    g++@edge \
-    gcc@edge
+    python3 \
+    python3-dev \
+    py3-lxml \
+    boost-python3  \
+    bash
 
 RUN \
  echo "**** install build packages ****" && \
@@ -28,6 +24,8 @@ RUN \
     automake \
     freetype-dev \
     jpeg-dev \
+    g++ \
+    gcc \
     lcms2-dev \
     libffi-dev \
     libpng-dev \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -7,19 +7,15 @@ FROM lsiobase/alpine:arm32v7-3.10
 
 # Add edge/testing repositories.
 RUN printf "\
-@edge http://nl.alpinelinux.org/alpine/edge/main\n\
 @testing http://nl.alpinelinux.org/alpine/edge/testing\n\
-@community http://nl.alpinelinux.org/alpine/edge/community\n\
 " >> /etc/apk/repositories
 
 RUN apk add \
-    python3@edge \
-    python3-dev@edge \
-    py3-lxml@edge \
-    boost-python3@edge  \
-    bash@edge \
-    g++@edge \
-    gcc@edge
+    python3 \
+    python3-dev \
+    py3-lxml \
+    boost-python3  \
+    bash \
 
 RUN \
  echo "**** install build packages ****" && \
@@ -27,6 +23,8 @@ RUN \
     autoconf \
     automake \
     freetype-dev \
+    g++ \
+    gcc \
     jpeg-dev \
     lcms2-dev \
     libffi-dev \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,17 +5,16 @@
 # - installing python 3.7.3 because that is what py3-libtorrent-rasterbar requires (doesn't work with 3.6.8)
 FROM lsiobase/alpine:arm32v7-3.10
 
-# Add edge/testing repositories.
-RUN printf "\
-@testing http://nl.alpinelinux.org/alpine/edge/testing\n\
-" >> /etc/apk/repositories
-
 RUN apk add \
     python3 \
     python3-dev \
     py3-lxml \
     boost-python3  \
-    bash \
+    bash && \
+    echo "**** install alpine sdk so that we can build libtorrent python bindings (for various plugin) ****" && \
+    apk add alpine-sdk && \
+    abuild-keygen -ian && \
+    usermod -aG abuild root
 
 RUN \
  echo "**** install build packages ****" && \
@@ -77,10 +76,18 @@ RUN \
     setuptools \
     urllib3 \
     virtualenv && \
+ echo "**** build libtorrent-rasterbar, this takes a bit ****" && \
+ mkdir -p /build/py3-libtorrent-rasterbar && \
+ cd /build/py3-libtorrent-rasterbar && \
+ wget https://git.alpinelinux.org/aports/plain/testing/libtorrent-rasterbar/APKBUILD && \
+ abuild -F checksum && abuild -Fr && \
+ apk add --repository /root/packages/build py3-libtorrent-rasterbar && \
  echo "**** clean up ****" && \
  rm -rf \
     /root/.cache \
-    /tmp/*
+    /tmp/* \
+    /build \
+    /root/packages
 
 ##############################################################################
 # Here starts the usual changes compared to baseimage.

--- a/etc/cont-init.d/20-update-flexget
+++ b/etc/cont-init.d/20-update-flexget
@@ -17,14 +17,13 @@ apk add --update --no-cache \
 
 # Dependency for libtorrent-rasterbar.
 apk add --no-cache \
-    boost-python3@edge \
-    boost-system@edge \
-    libressl-dev@edge
+    boost-system \
+    libressl-dev
 
 # libtorrent-rasterbar contains the python bindings for libtorrent.
 apk add --no-cache \
-    libcrypto1.1@edge \
-    libssl1.1@edge \
+    libcrypto1.1 \
+    libssl1.1 \
     py3-libtorrent-rasterbar@testing
 
 # Install flexget last (it might force specific versions of other packages).

--- a/etc/cont-init.d/20-update-flexget
+++ b/etc/cont-init.d/20-update-flexget
@@ -10,21 +10,5 @@ pip install -U python-telegram-bot
 pip install -U rarfile
 pip install -U subliminal
 
-# Install libtorrent-rasterbar, a dependency for e.g.
-# flexget plugin `convert_magnet`.
-apk add --update --no-cache \
-    apk-tools
-
-# Dependency for libtorrent-rasterbar.
-apk add --no-cache \
-    boost-system \
-    libressl-dev
-
-# libtorrent-rasterbar contains the python bindings for libtorrent.
-apk add --no-cache \
-    libcrypto1.1 \
-    libssl1.1 \
-    py3-libtorrent-rasterbar@testing
-
 # Install flexget last (it might force specific versions of other packages).
 pip install -U flexget


### PR DESCRIPTION
@cpoppema now that edge is at Python 3.8 all sorts of stuff breaks, including flexget itself with some API incompatibilities, additionally, the container can no longer be built successfully using `docker build`. If I understand the commit log correctly, the original reason to be on edge is to get Python 3.7 for libtorrent-rasterbar?

If so, now 3.10 is on Python 3.7 without any other additional manipulation I'm guessing that it would make sense to remove the installs from the edge repository and just use the repos that come with 3.10. The only thing that would be left out of this, is the fact that libtorrent-rasterbar itself is only available on edge testing, however pulling in Python 3.8 at all causes a lot of issues. So in this PR I mitigate that by building it using `abuilder` so that it can bind to whatever version of Python is available (Python 3.7 at present).

Since I chose to build `libtorrent-rasterbar` with the alpine `abuilder` utility, it makes this script take a bit longer during `docker build` (about 15 min on my machine) but it speeds up and simplifies the container at runtime.

This PR should fix #55 and remove the apk changes he was talking about that happen in the s6 config init script.

I've built this image myself (the arm ones I just copied syntax as I don't have a good way to test them) and have been running it for a few hours and it seems good.