### PR TITLE
pulling last version of python-telegram-bot ~ v12.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ urllib3[socks]
 chardet
 cloudscraper
 irc_bot
-python-telegram-bot
+python-telegram-bot<13
 rarfile
 sleekxmpp
 subliminal


### PR DESCRIPTION
This is a temp fix for err - module 'pytz' has no attribute 'BaseTzInfo'

cause: pytz 2017.2 is not compatible with tgbot 13.0.